### PR TITLE
Support runtime directories for a Flatpak installation

### DIFF
--- a/src/linuxMain/kotlin/io/github/vyfor/kpresence/ipc/Connection.kt
+++ b/src/linuxMain/kotlin/io/github/vyfor/kpresence/ipc/Connection.kt
@@ -20,6 +20,7 @@ actual class Connection {
           listOf(
             base,
             "$base/app/com.discordapp.Discord",
+            "$base/.flatpak/com.discordapp.Discord",
             "$base/snap.discord"
           )
         }


### PR DESCRIPTION
`$base/.flatpak`  reflects a move towards clearer and stricter namespace management for Flatpak applications, reducing the chances of conflicts with non-Flatpak applications.

Currenly, KPresence expects this path `$base/app/com.discordapp.Discord`, which seams to be outdated.

https://github.com/pandier/intellij-discord-rp/issues/92#issuecomment-2505318380